### PR TITLE
handle alternative configs

### DIFF
--- a/bps/bps_butler_config.yaml
+++ b/bps/bps_butler_config.yaml
@@ -1,0 +1,3 @@
+includeConfigs:
+  - resource://lsst.ctrl.bps/etc/bps_qbb.yaml
+#  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml

--- a/bps/bps_eoBFAnalysis.yaml
+++ b/bps/bps_eoBFAnalysis.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoBFAnalysis.yaml
 extraQgraphOptions: "--config bfAnalysisTask:acq_run=' ${PTC_RUN}' --config bfAnalysisFpPlotsTask:acq_run=' ${PTC_RUN}'"

--- a/bps/bps_eoBFAnalysis.yaml
+++ b/bps/bps_eoBFAnalysis.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config bfAnalysisTask:acq_run=' ${PTC_RUN}' --config bfAn
 payload:
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_bf_analysis_{ptc_run}_{weekly}
+  payloadName: eo_bf_analysis{payload_modifier}_{ptc_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/bps_eoBiasShifts.yaml
+++ b/bps/bps_eoBiasShifts.yaml
@@ -9,7 +9,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${INSTRUMENT_NAME}/raw/all
-  payloadName: eo_bias_shifts_{b_protocol_run}_{weekly}
+  payloadName: eo_bias_shifts{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type!='scan'"

--- a/bps/bps_eoBiasShifts.yaml
+++ b/bps/bps_eoBiasShifts.yaml
@@ -1,6 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoBiasShifts.yaml
 extraQgraphOptions: "--config biasShiftsFpPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoBiasStability.yaml
+++ b/bps/bps_eoBiasStability.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoBiasStability.yaml
 extraQgraphOptions: "--config biasStabilityPlots:acq_run=' ${B_PROTOCOL_RUN}' --config biasStability:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoBiasStability.yaml
+++ b/bps/bps_eoBiasStability.yaml
@@ -11,7 +11,8 @@ payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_bias_stability_{b_protocol_run}_{weekly}
+  payloadName: eo_bias_stability{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.observation_type='bias' and exposure.science_program='{b_protocol_run}'"

--- a/bps/bps_eoBrightDefects.yaml
+++ b/bps/bps_eoBrightDefects.yaml
@@ -8,7 +8,8 @@ extraQgraphOptions: "--config brightDefectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_bright_defects_{b_protocol_run}_{weekly}
+  payloadName: eo_bright_defects{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='dark' and exposure.observation_reason='dark'"

--- a/bps/bps_eoBrightDefects.yaml
+++ b/bps/bps_eoBrightDefects.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: "${EO_PIPE_DIR}/pipelines/eoBrightDefects.yaml"
 extraQgraphOptions: "--config brightDefectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoCtiPlotsTask.yaml
+++ b/bps/bps_eoCtiPlotsTask.yaml
@@ -6,8 +6,9 @@ project: "{outputRun}"
 payload:
   b_protocol_run: 13162
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: u/jchiang/deferredCharge_{b_protocol_run}_w_2022_48
-  payloadName: cti_plots_{b_protocol_run}_{weekly}
+  payloadName: eo_cti_plots{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='LSSTCam'"
 

--- a/bps/bps_eoCtiVsFlux.yaml
+++ b/bps/bps_eoCtiVsFlux.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoCtiVsFlux.yaml
 extraQgraphOptions: "--config ctiVsFluxTask:acq_run=' ${PTC_RUN}'"

--- a/bps/bps_eoCtiVsFlux.yaml
+++ b/bps/bps_eoCtiVsFlux.yaml
@@ -9,7 +9,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_cti_vs_flux_{ptc_run}_{weekly}
+  payloadName: eo_cti_vs_flux{payload_modifier}_{ptc_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{ptc_run}' and exposure.observation_type='flat' and exposure.observation_reason='flat'"

--- a/bps/bps_eoDarkCurrent.yaml
+++ b/bps/bps_eoDarkCurrent.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config darkCurrentTask:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_dark_current_{b_protocol_run}_{weekly}
+  payloadName: eo_dark_current{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/bps_eoDarkCurrent.yaml
+++ b/bps/bps_eoDarkCurrent.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoDarkCurrent.yaml
 extraQgraphOptions: "--config darkCurrentTask:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoDarkDefects.yaml
+++ b/bps/bps_eoDarkDefects.yaml
@@ -8,7 +8,8 @@ extraQgraphOptions: "--config darkDefectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_dark_defects_{b_protocol_run}_{weekly}
+  payloadName: eo_dark_defects{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_hi') and physical_filter='${HIGH_FLUX_FILTER}'"

--- a/bps/bps_eoDarkDefects.yaml
+++ b/bps/bps_eoDarkDefects.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: "${EO_PIPE_DIR}/pipelines/eoDarkDefects.yaml"
 extraQgraphOptions: "--config darkDefectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoDarkMosaic.yaml
+++ b/bps/bps_eoDarkMosaic.yaml
@@ -7,7 +7,8 @@ pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoDarkMosaic.yaml
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: dark_mosaic_{b_protocol_run}_{weekly}
+  payloadName: dark_mosaic{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure=${EXPOSURE_ID}"

--- a/bps/bps_eoDarkMosaic.yaml
+++ b/bps/bps_eoDarkMosaic.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoDarkMosaic.yaml
 

--- a/bps/bps_eoDefects.yaml
+++ b/bps/bps_eoDefects.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: "${EO_PIPE_DIR}/pipelines/eoDefects.yaml"
 extraQgraphOptions: "--config defectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoDefects.yaml
+++ b/bps/bps_eoDefects.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config defectsPlots:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: u/jchiang/ptc_0_13144_w_2023_09
-  payloadName: eo_defects_{b_protocol_run}_{weekly}
+  payloadName: eo_defects{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='LSSTCam'"

--- a/bps/bps_eoDivisaderoTearing.yaml
+++ b/bps/bps_eoDivisaderoTearing.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config divisaderoRaftPlots:acq_run=' ${B_PROTOCOL_RUN}' -
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_divisadero_tearing_{b_protocol_run}_{weekly}
+  payloadName: eo_divisadero_tearing{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/bps_eoDivisaderoTearing.yaml
+++ b/bps/bps_eoDivisaderoTearing.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoDivisaderoTearing.yaml
 extraQgraphOptions: "--config divisaderoRaftPlots:acq_run=' ${B_PROTOCOL_RUN}' --config divisaderoFpPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoEper.yaml
+++ b/bps/bps_eoEper.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config eperFpPlots:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_eper_{b_protocol_run}_{weekly}
+  payloadName: eo_eper{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_lo', 'sflat_hi')"

--- a/bps/bps_eoEper.yaml
+++ b/bps/bps_eoEper.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoEper.yaml
 extraQgraphOptions: "--config eperFpPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoFlatGainStability.yaml
+++ b/bps/bps_eoFlatGainStability.yaml
@@ -9,7 +9,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   gain_stability_run: ${GAIN_STABILITY_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION},${INSTRUMENT_NAME}/photodiode
-  payloadName: eo_flat_gain_stability_{gain_stability_run}_{weekly}
+  payloadName: eo_flat_gain_stability{payload_modifier}_{gain_stability_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_lo', 'sflat_hi') and exposure.science_program='{gain_stability_run}'"

--- a/bps/bps_eoFlatGainStability.yaml
+++ b/bps/bps_eoFlatGainStability.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoFlatGainStability.yaml
 extraQgraphOptions: "--config flatGainStabilityTask:ccob_led_constraint='${CCOBLED}' --config flatGainStabilityPlots:acq_run=' ${GAIN_STABILITY_RUN}' --config flatGainStabilityPlots:ccob_led_constraint='${CCOBLED}'"

--- a/bps/bps_eoFocalPlaneMosaic.yaml
+++ b/bps/bps_eoFocalPlaneMosaic.yaml
@@ -7,7 +7,8 @@ pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoFocalPlaneMosaic.yaml
 payload:
   exposure_id: ${EXPOSURE_ID}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_focal_plane_mosaic_{exposure_id}_{weekly}
+  payloadName: eo_focal_plane_mosaic{payload_modifier}_{exposure_id}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure=${EXPOSURE_ID} and detector in (0..188)"

--- a/bps/bps_eoFocalPlaneMosaic.yaml
+++ b/bps/bps_eoFocalPlaneMosaic.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoFocalPlaneMosaic.yaml
 

--- a/bps/bps_eoLinearityPlots.yaml
+++ b/bps/bps_eoLinearityPlots.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config linearityFocalPlanePlots:acq_run=' ${PTC_RUN}'"
 payload:
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION},${INSTRUMENT_NAME}/photodiode
-  payloadName: eo_linearity_plots_{ptc_run}_{weekly}
+  payloadName: eo_linearity_plots{payload_modifier}_{ptc_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{ptc_run}'"

--- a/bps/bps_eoLinearityPlots.yaml
+++ b/bps/bps_eoLinearityPlots.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoLinearityPlots.yaml
 extraQgraphOptions: "--config linearityFocalPlanePlots:acq_run=' ${PTC_RUN}'"

--- a/bps/bps_eoPersistence.yaml
+++ b/bps/bps_eoPersistence.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoPersistence.yaml
 extraQgraphOptions: "--config persistence:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoPersistence.yaml
+++ b/bps/bps_eoPersistence.yaml
@@ -8,7 +8,8 @@ extraQgraphOptions: "--config persistence:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_persistence_{b_protocol_run}_{weekly}
+  payloadName: eo_persistence{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type in ('dark', 'flat') and exposure.observation_reason='bot_persistence'"

--- a/bps/bps_eoPtcPlots.yaml
+++ b/bps/bps_eoPtcPlots.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoPtcPlots.yaml
 extraQgraphOptions: "--config ptcPlots:acq_run=' ${PTC_RUN}' --config ptcFocalPlanePlots:acq_run=' ${PTC_RUN}' --config rowMeansVariance:acq_run=' ${PTC_RUN}' --config rowMeansVarianceFpPlot:acq_run=' ${PTC_RUN}'"

--- a/bps/bps_eoPtcPlots.yaml
+++ b/bps/bps_eoPtcPlots.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config ptcPlots:acq_run=' ${PTC_RUN}' --config ptcFocalPl
 payload:
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_ptc_plots_{ptc_run}_{weekly}
+  payloadName: eo_ptc_plots{payload_modifier}_{ptc_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/bps_eoRaftAmpCorrelations.yaml
+++ b/bps/bps_eoRaftAmpCorrelations.yaml
@@ -9,7 +9,8 @@ payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_raft_amp_correlations_{b_protocol_run}_{weekly}
+  payloadName: eo_raft_amp_correlations{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and ((exposure.observation_type='bias' and exposure.observation_reason='bias') or (exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_hi') and physical_filter='${HIGH_FLUX_FILTER}'))"

--- a/bps/bps_eoRaftAmpCorrelations.yaml
+++ b/bps/bps_eoRaftAmpCorrelations.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoRaftAmpCorrelations.yaml
 

--- a/bps/bps_eoRaftCalibMosaics.yaml
+++ b/bps/bps_eoRaftCalibMosaics.yaml
@@ -7,7 +7,8 @@ extraQgraphOptions: "--config raftCalibMosaic:acq_run=' ${B_PROTOCOL_RUN}'"
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_raft_calib_mosaics_{b_protocol_run}_{weekly}
+  payloadName: eo_raft_calib_mosaics{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/bps_eoRaftCalibMosaics.yaml
+++ b/bps/bps_eoRaftCalibMosaics.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoRaftCalibMosaics.yaml
 extraQgraphOptions: "--config raftCalibMosaic:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoRaftLambdaMosaics.yaml
+++ b/bps/bps_eoRaftLambdaMosaics.yaml
@@ -7,7 +7,8 @@ pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoRaftMosaics.yaml
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_raft_lambda_mosaics_{b_protocol_run}_{weekly}
+  payloadName: eo_raft_lambda_mosaics{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_reason='lambda'"

--- a/bps/bps_eoRaftLambdaMosaics.yaml
+++ b/bps/bps_eoRaftLambdaMosaics.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoRaftMosaics.yaml
 

--- a/bps/bps_eoReadNoise.yaml
+++ b/bps/bps_eoReadNoise.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoReadNoise.yaml
 extraQgraphOptions: "--config readNoiseFpPlots:acq_run=' ${B_PROTOCOL_RUN}'"

--- a/bps/bps_eoReadNoise.yaml
+++ b/bps/bps_eoReadNoise.yaml
@@ -10,7 +10,8 @@ payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   ptc_run: ${PTC_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_read_noise_{b_protocol_run}_{weekly}
+  payloadName: eo_read_noise{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.observation_reason='bias' and exposure.science_program='{b_protocol_run}'"

--- a/bps/bps_eoRunInfo.yaml
+++ b/bps/bps_eoRunInfo.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoRunInfo.yaml
 

--- a/bps/bps_eoRunInfo.yaml
+++ b/bps/bps_eoRunInfo.yaml
@@ -8,7 +8,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   acq_run: ${ACQ_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${INSTRUMENT_NAME}/raw/all
-  payloadName: eo_run_info_{acq_run}_{weekly}
+  payloadName: eo_run_info{payload_modifier}_{acq_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{acq_run}' and detector in (20)"

--- a/bps/bps_eoScanMode.yaml
+++ b/bps/bps_eoScanMode.yaml
@@ -8,7 +8,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${INSTRUMENT_NAME}/raw/all
-  payloadName: eo_scan_mode_{b_protocol_run}_{weekly}
+  payloadName: eo_scan_mode{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.observation_type='scan' and exposure.observation_reason='scan' and exposure.science_program='{b_protocol_run}'"

--- a/bps/bps_eoScanMode.yaml
+++ b/bps/bps_eoScanMode.yaml
@@ -1,5 +1,5 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoScanMode.yaml
 

--- a/bps/bps_eoSpotMeasurement.yaml
+++ b/bps/bps_eoSpotMeasurement.yaml
@@ -1,5 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_eo_pipe_isr_options.yaml
 
 pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoSpotMeasurement.yaml
 

--- a/bps/bps_eoSpotMeasurement.yaml
+++ b/bps/bps_eoSpotMeasurement.yaml
@@ -7,7 +7,8 @@ pipelineYaml: ${EO_PIPE_DIR}/pipelines/eoSpotMeasurement.yaml
 payload:
   spot_run: ${SPOT_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${EO_PIPE_INCOLLECTION}
-  payloadName: eo_spot_measurements_{spot_run}_{weekly}
+  payloadName: eo_spot_measurements{payload_modifier}_{spot_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{spot_run}' and exposure.observation_type='ccobthin' and exposure.observation_reason='ccobthin'"

--- a/bps/bps_eo_pipe_isr_options.yaml
+++ b/bps/bps_eo_pipe_isr_options.yaml
@@ -1,0 +1,3 @@
+# These are the defaults in the pipeline yamls in eo_pipe/pipelines.  Edit
+# them locally to enable different options.
+extraQgraphOptions: "--config isr:overscan.doParallelOverscan=True --config isr:overscan.fitType='MEDIAN_PER_ROW' --config isr:overscan.leadingColumnsToSkip=2 --config isr:overscan.leadingRowsToSkip=2"

--- a/bps/cp_pipe/bps_cpBias.yaml
+++ b/bps/cp_pipe/bps_cpBias.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False"
@@ -11,7 +11,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   inCollection: ${INSTRUMENT_NAME}/raw/all,${INSTRUMENT_NAME}/calib/unbounded
-  payloadName: bias_{b_protocol_run}_{weekly}
+  payloadName: bias{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='bias' and exposure.observation_reason='bias'"

--- a/bps/cp_pipe/bps_cpBias.yaml
+++ b/bps/cp_pipe/bps_cpBias.yaml
@@ -1,7 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False"
 

--- a/bps/cp_pipe/bps_cpDark.yaml
+++ b/bps/cp_pipe/bps_cpDark.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False --config cpDark:repair.doCosmicRay=False"
@@ -11,7 +11,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
-  inCollection: u/{operator}/bias_{b_protocol_run}_{weekly}
-  payloadName: dark_{b_protocol_run}_{weekly}
+  payload_modifier: ${PAYLOAD_MODIFIER}
+  inCollection: u/{operator}/bias{payload_modifier}_{b_protocol_run}_{weekly}
+  payloadName: dark{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='dark' and exposure.observation_reason='dark'"

--- a/bps/cp_pipe/bps_cpDark.yaml
+++ b/bps/cp_pipe/bps_cpDark.yaml
@@ -1,7 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False --config cpDark:repair.doCosmicRay=False"
 

--- a/bps/cp_pipe/bps_cpFlat.yaml
+++ b/bps/cp_pipe/bps_cpFlat.yaml
@@ -1,7 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False --config isr:doLinearize=False --config cpFlatCombine:exposureScaling='Unity'"
 

--- a/bps/cp_pipe/bps_cpFlat.yaml
+++ b/bps/cp_pipe/bps_cpFlat.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doDefect=False --config isr:doLinearize=False --config cpFlatCombine:exposureScaling='Unity'"
@@ -11,7 +11,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
-  inCollection: u/{operator}/dark_{b_protocol_run}_{weekly}
-  payloadName: flat_{b_protocol_run}_{weekly}
+  payload_modifier: ${PAYLOAD_MODIFIER}
+  inCollection: u/{operator}/dark{payload_modifier}_{b_protocol_run}_{weekly}
+  payloadName: flat{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_hi') and physical_filter='${HIGH_FLUX_FILTER}'"

--- a/bps/cp_pipe/bps_cpPtc.yaml
+++ b/bps/cp_pipe/bps_cpPtc.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 # For CCOB data:
@@ -15,8 +15,9 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   ptc_run: ${PTC_RUN}
   b_protocol_run: ${B_PROTOCOL_RUN}
+  payload_modifier: ${PAYLOAD_MODIFIER}
   weekly: ${WEEKLY}
-  inCollection: u/{operator}/defects_{b_protocol_run}_{weekly}
-  payloadName: ptc_{ptc_run}_{weekly}
+  inCollection: u/{operator}/defects{payload_modifier}_{b_protocol_run}_{weekly},${INSTRUMENT_NAME}/photodiode
+  payloadName: ptc{payload_modifier}_{ptc_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{ptc_run}' and exposure.observation_type='flat' and exposure.observation_reason='flat'"

--- a/bps/cp_pipe/bps_cpPtc.yaml
+++ b/bps/cp_pipe/bps_cpPtc.yaml
@@ -1,10 +1,9 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 # For CCOB data:
-extraQgraphOptions: "{isr_QgraphOptions} --config isr:doLinearize=False --config ptcExtract:matchExposuresType='FLUX' --config ptcExtract:matchExposuresByFluxKeyword='CCOBFLUX'"
+extraQgraphOptions: "{isr_QgraphOptions} --config isr:doLinearize=False --config ptcExtract:matchExposuresType='FLUX' --config ptcExtract:matchExposuresByFluxKeyword='CCOBFLUX' --config ptcSolve:ksTestMinPvalue=0.0"
 
 ## For Run 5 data:
 #extraQgraphOptions: "{isr_QgraphOptions} --config isr:doLinearize=False"

--- a/bps/cp_pipe/bps_cpPtc_subset.yaml
+++ b/bps/cp_pipe/bps_cpPtc_subset.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${CP_PIPE_PROCESSING_DIR}/bps/bps_default_configs.yaml
 
 # For CCOB data:

--- a/bps/cp_pipe/bps_cpPtc_subset.yaml
+++ b/bps/cp_pipe/bps_cpPtc_subset.yaml
@@ -1,7 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${CP_PIPE_PROCESSING_DIR}/bps/bps_default_configs.yaml
 
 # For CCOB data:
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doLinearize=False --config ptcExtract:matchExposuresType='FLUX' --config ptcExtract:matchExposuresByFluxKeyword='CCOBFLUX'"

--- a/bps/cp_pipe/bps_findDefects.yaml
+++ b/bps/cp_pipe/bps_findDefects.yaml
@@ -1,6 +1,6 @@
 includeConfigs:
   - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
-  - ${EO_PIPE_DIR}/bps/cp_pipe/bps_qgraph_options.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 #  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doSaturation=False"
@@ -11,7 +11,8 @@ instrument: ${INSTRUMENT_CLASS}
 payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
-  inCollection: u/{operator}/flat_{b_protocol_run}_{weekly}
-  payloadName: defects_{b_protocol_run}_{weekly}
+  payload_modifier: ${PAYLOAD_MODIFIER}
+  inCollection: u/{operator}/flat{payload_modifier}_{b_protocol_run}_{weekly}
+  payloadName: defects{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and ((exposure.observation_type='dark' and exposure.observation_reason='dark') or (exposure.observation_type='flat' and exposure.observation_reason in ('sflat', 'sflat_hi') and physical_filter='${HIGH_FLUX_FILTER}'))"

--- a/bps/cp_pipe/bps_findDefects.yaml
+++ b/bps/cp_pipe/bps_findDefects.yaml
@@ -1,7 +1,6 @@
 includeConfigs:
-  - ${EO_PIPE_DIR}/bps/bps_htcondor_configs.yaml
+  - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
-#  - ${EO_PIPE_DIR}/bps/parsl/bps_gen3_workflow_configs.yaml
 
 extraQgraphOptions: "{isr_QgraphOptions} --config isr:doSaturation=False"
 

--- a/data/cp_pipelines_config.yaml
+++ b/data/cp_pipelines_config.yaml
@@ -5,6 +5,7 @@ baseline:
     - INSTRUMENT_CLASS_NAME
     - INSTRUMENT_CLASS
     - INSTRUMENT_NAME
+    - PAYLOAD_MODIFIER
 
 b_protocol:
   pipelines:

--- a/data/eo_pipe_config.yaml
+++ b/data/eo_pipe_config.yaml
@@ -6,6 +6,7 @@ baseline:
     - INSTRUMENT_CLASS
     - INSTRUMENT_NAME
     - EO_PIPE_INCOLLECTION
+    - PAYLOAD_MODIFIER
 
 b_protocol:
   pipelines:

--- a/python/lsst/eo/pipe/eoPipelines.py
+++ b/python/lsst/eo/pipe/eoPipelines.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import shutil
 import time
 import datetime
 import yaml
@@ -136,6 +137,17 @@ class CpPipelines(EoPipelines):
     """
     def __init__(self, cp_pipeline_config, verbose=True, dry_run=False):
         super().__init__(cp_pipeline_config, verbose=verbose, dry_run=dry_run)
+        self._cp_bps_qgraph_options()
+
+    def _cp_bps_qgraph_options(self):
+        target_folder = os.path.join('bps', 'cp_pipe')
+        qgraph_options_file = 'bps_qgraph_options.yaml'
+        os.makedirs(target_folder, exist_ok=True)
+        dest_file = os.path.join(target_folder, qgraph_options_file)
+        if not os.path.isfile(dest_file):
+            src_file = os.path.join(os.environ['EO_PIPE_DIR'], target_folder,
+                                    qgraph_options_file)
+            shutil.copy(src_file, dest_file)
 
     def _print_inCollection(self):
         pass

--- a/python/lsst/eo/pipe/eoPipelines.py
+++ b/python/lsst/eo/pipe/eoPipelines.py
@@ -39,7 +39,7 @@ class PipelinesBase:
         os.makedirs(log_dir, exist_ok=True)
         with open(pipeline_config) as fobj:
             self.config = yaml.safe_load(fobj)
-        self._cp_bps_options_file('bps/bps_butler_config.yaml')
+        self._copy_bps_options_file('bps/bps_butler_config.yaml')
 
     def _check_env_vars(self, run_type):
         # Check for required env vars for the specified run type.
@@ -55,7 +55,7 @@ class PipelinesBase:
             raise RuntimeError("Missing required environment variables: "
                                f"{missing}")
 
-    def _cp_bps_options_file(self, options_file_rel_path):
+    def _copy_bps_options_file(self, options_file_rel_path):
         dest_folder = os.path.dirname(options_file_rel_path)
         os.makedirs(dest_folder, exist_ok=True)
         if not os.path.isfile(options_file_rel_path):
@@ -121,7 +121,7 @@ class EoPipelines(PipelinesBase):
                  log_dir='./logs'):
         super().__init__(eo_pipeline_config, verbose=verbose, dry_run=dry_run,
                          log_dir=log_dir)
-        self._cp_bps_options_file('bps/bps_eo_pipe_isr_options.yaml')
+        self._copy_bps_options_file('bps/bps_eo_pipe_isr_options.yaml')
 
     def _print_in_collection(self):
         print("Using input collection:")
@@ -164,7 +164,7 @@ class CpPipelines(PipelinesBase):
     def __init__(self, cp_pipeline_config, verbose=True, dry_run=False,
                  log_dir='./logs'):
         super().__init__(cp_pipeline_config, verbose=verbose, dry_run=dry_run)
-        self._cp_bps_options_file('bps/cp_pipe/bps_qgraph_options.yaml')
+        self._copy_bps_options_file('bps/cp_pipe/bps_qgraph_options.yaml')
 
     def _run_pipelines(self, pipelines):
         for pipeline in pipelines:


### PR DESCRIPTION
* Enable use of alternative pipeline task configs for `cp_pipe` and `eo_pipe`
  * Use local copies of QG options for `cp_pipe` and `eo_pipe`
  * Add env var for modifying the payload names
* Use local config file for controlling bps-related options: enabling QBB or switching to parsl-based plugin
* Refactor `eoPipelines.py` to handle these new options.
* set `--config ptcSolve:ksTestMinPvalue=0.0` in `bps_cpPtc.yaml` to avoid rejecting too many points from the ptc mean vs variance data.