### PR TITLE
QuantumGraph generation-related changes

### DIFF
--- a/bps/bps_eoBiasShifts.yaml
+++ b/bps/bps_eoBiasShifts.yaml
@@ -10,7 +10,7 @@ payload:
   b_protocol_run: ${B_PROTOCOL_RUN}
   weekly: ${WEEKLY}
   payload_modifier: ${PAYLOAD_MODIFIER}
-  inCollection: ${INSTRUMENT_NAME}/raw/all
+  inCollection: ${INSTRUMENT_NAME}/raw/all,${INSTRUMENT_NAME}/calib/unbounded
   payloadName: eo_bias_shifts{payload_modifier}_{b_protocol_run}_{weekly}
   butlerConfig: ${BUTLER_CONFIG}
   dataQuery: "instrument='${INSTRUMENT_NAME}' and exposure.science_program='{b_protocol_run}' and exposure.observation_type!='scan' ${DETECTOR_SELECTION}"

--- a/python/lsst/eo/pipe/bfAnalysisTask.py
+++ b/python/lsst/eo/pipe/bfAnalysisTask.py
@@ -3,7 +3,6 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 import matplotlib.pyplot as plt
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -49,8 +48,7 @@ class BFAnalysisTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
 
     bf_stats = cT.Output(name="bf_stats",
                          doc="Brighter-Fatter covariance statistics",
@@ -179,8 +177,7 @@ class BFAnalysisFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     bf_xcorr_plot = cT.Output(
         name="bf_xcorr_plot",

--- a/python/lsst/eo/pipe/biasShiftsTask.py
+++ b/python/lsst/eo/pipe/biasShiftsTask.py
@@ -4,7 +4,6 @@ import pandas as pd
 import scipy.signal
 import scipy.stats
 import numpy as np
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -272,8 +271,7 @@ class BiasShiftsFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
 
     bias_shifts_plot = cT.Output(name="bias_shifts_plot",
                                  doc=("Plot of the number of exposures per amp "

--- a/python/lsst/eo/pipe/biasStabilityTask.py
+++ b/python/lsst/eo/pipe/biasStabilityTask.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import lsst.afw.math as afwMath
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.geom
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -75,8 +74,7 @@ class BiasStabilityTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
     bias_stability_stats = cT.Output(name="bias_stability_stats",
                            doc="bias stability statistics",
                            storageClass="DataFrame",
@@ -212,8 +210,7 @@ class BiasStabilityPlotsTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
     bias_mean_vs_time_plot = cT.Output(name="bias_mean_vs_time_plot",
                                        doc="Plot of bias mean vs time",
                                        storageClass="Plot",

--- a/python/lsst/eo/pipe/ctiPlotsTask.py
+++ b/python/lsst/eo/pipe/ctiPlotsTask.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import matplotlib.pyplot as plt
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -33,8 +32,7 @@ class CtiFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     serial_cti = cT.Output(
         name="serial_cti",

--- a/python/lsst/eo/pipe/ctiVsFluxTask.py
+++ b/python/lsst/eo/pipe/ctiVsFluxTask.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import lsst.afw.math as afw_math
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -76,8 +75,7 @@ class CtiVsFluxTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     cti_vs_flux = cT.Output(
         name="cti_vs_flux",

--- a/python/lsst/eo/pipe/darkCurrentTask.py
+++ b/python/lsst/eo/pipe/darkCurrentTask.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -53,8 +52,7 @@ class DarkCurrentTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     dark_current_stats = cT.Output(
         name="dark_current_stats",

--- a/python/lsst/eo/pipe/defectsTask.py
+++ b/python/lsst/eo/pipe/defectsTask.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 import pandas as pd
 
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 from lsst.cp.pipe import MergeDefectsTaskConfig, MergeDefectsTask
 import lsst.daf.butler as daf_butler
 import lsst.geom
@@ -144,8 +143,7 @@ class DefectsPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
 
 class DefectsPlotsTaskConfig(pipeBase.PipelineTaskConfig,

--- a/python/lsst/eo/pipe/divisaderoTearingTask.py
+++ b/python/lsst/eo/pipe/divisaderoTearingTask.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import astropy.stats
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -52,8 +51,7 @@ class DivisaderoTearingTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     divisadero_response = cT.Output(
         name="divisadero_response",
@@ -221,8 +219,7 @@ class DivisaderoRaftPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     divisadero_raft_plot = cT.Output(
         name="divisadero_raft_plot",
@@ -311,8 +308,7 @@ class DivisaderoFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     divisadero_tearing = cT.Output(
         name="divisadero_tearing_plot",

--- a/python/lsst/eo/pipe/eperTask.py
+++ b/python/lsst/eo/pipe/eperTask.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import lsst.afw.math as afw_math
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 from lsst.geom import Box2I, Extent2I, Point2I
 import lsst.pex.config as pexConfig
@@ -103,8 +102,7 @@ class EperTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     eper_stats = cT.Output(
         name="eper_stats",
@@ -216,8 +214,7 @@ class EperFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     scti_eper_plot = cT.Output(
         name="scti_eper_plot",

--- a/python/lsst/eo/pipe/flatGainStabilityTask.py
+++ b/python/lsst/eo/pipe/flatGainStabilityTask.py
@@ -3,7 +3,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import lsst.afw.math as afw_math
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -57,8 +56,7 @@ class FlatGainStabilityTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     flat_gain_stability_stats = cT.Output(
         name="flat_gain_stability_stats",
@@ -195,8 +193,7 @@ class FlatGainStabilityPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     flat_gain_stability_plots = cT.Output(
         name="flat_gain_stability_plots",

--- a/python/lsst/eo/pipe/focalPlaneMosaicTask.py
+++ b/python/lsst/eo/pipe/focalPlaneMosaicTask.py
@@ -1,5 +1,4 @@
 from lsst.afw.cameraGeom import utils as cgu
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -24,8 +23,7 @@ class FocalPlaneMosaicTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     output_mosaic = cT.Output(
         name="eoFpMosaic",

--- a/python/lsst/eo/pipe/linearityPlotsTask.py
+++ b/python/lsst/eo/pipe/linearityPlotsTask.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import numpy as np
 import matplotlib.pyplot as plt
 import pandas as pd
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -109,8 +108,7 @@ class LinearityPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     linearity_plots = cT.Output(
         name="linearity_fit_plot",
@@ -322,8 +320,7 @@ class LinearityFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     max_frac_dev = cT.Output(name="max_frac_dev",
                              doc=("Maximum fractional deviation from "

--- a/python/lsst/eo/pipe/ptcPlotsTask.py
+++ b/python/lsst/eo/pipe/ptcPlotsTask.py
@@ -5,7 +5,6 @@ import matplotlib.pyplot as plt
 import pandas as pd
 
 import lsst.afw.math as afwMath
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 from lsst.cp.pipe.utils import funcAstier, funcPolynomial
 import lsst.daf.butler as daf_butler
 import lsst.geom
@@ -94,8 +93,7 @@ class PtcPlotsTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
     ptc_plots = cT.Output(name="ptc_plots",
                           doc=("Plots of photon transfer curves for each "
                                "amp in a CCD"),
@@ -195,8 +193,7 @@ class PtcFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
     ptc_summary = cT.Output(name="ptc_summary",
                             doc="Summary of PTC-related measurements",
                             storageClass="DataFrame",
@@ -493,8 +490,7 @@ class RowMeansVarianceFpPlotTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     row_means_variance_slopes = cT.Output(
         name="row_means_variance_slopes_plot",

--- a/python/lsst/eo/pipe/raftAmpCorrelationsTask.py
+++ b/python/lsst/eo/pipe/raftAmpCorrelationsTask.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import matplotlib.pyplot as plt
 
 from lsst.afw.cameraGeom import utils as cgu
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -36,8 +35,7 @@ class ImagingCorrelationsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     imaging_correlation_plot = cT.Output(
         name="imaging_correlation_plot",
@@ -131,8 +129,7 @@ class OverscanCorrelationsTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     overscan_correlation_plot = cT.Output(
         name="overscan_correlation_plot",

--- a/python/lsst/eo/pipe/raftCalibMosaicTask.py
+++ b/python/lsst/eo/pipe/raftCalibMosaicTask.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import matplotlib.pyplot as plt
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -50,8 +49,7 @@ class RaftCalibMosaicTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     bias_mosaic = cT.Output(
         name="raft_bias_mosaic",

--- a/python/lsst/eo/pipe/raftMosaicTask.py
+++ b/python/lsst/eo/pipe/raftMosaicTask.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import matplotlib.pyplot as plt
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
@@ -31,8 +30,7 @@ class RaftMosaicTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     raft_mosaic_plot = cT.Output(
         name="eoRaftMosaic",

--- a/python/lsst/eo/pipe/readNoiseTask.py
+++ b/python/lsst/eo/pipe/readNoiseTask.py
@@ -7,7 +7,6 @@ import pandas as pd
 from astro_metadata_translator import ObservationInfo
 
 import lsst.afw.math as afwMath
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.daf.butler as daf_butler
 import lsst.geom
 from lsst.obs.lsst import LsstCam
@@ -149,8 +148,7 @@ class ReadNoiseFpPlotsTaskConnections(pipeBase.PipelineTaskConnections,
                                   doc="Camera used in observations",
                                   storageClass="Camera",
                                   isCalibration=True,
-                                  dimensions=("instrument",),
-                                  lookupFunction=lookupStaticCalibration)
+                                  dimensions=("instrument",))
 
     read_noise_plot = cT.Output(name="read_noise_plot",
                                 doc="Focal plane plot of read noise values",

--- a/python/lsst/eo/pipe/scanModeTask.py
+++ b/python/lsst/eo/pipe/scanModeTask.py
@@ -2,7 +2,6 @@ import os
 from collections import defaultdict
 from astropy.io import fits
 import matplotlib.pyplot as plt
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.pipe.base as pipeBase
 from lsst.pipe.base import connectionTypes as cT
 
@@ -55,8 +54,7 @@ class ScanModeTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     scan_mode_dispersion_plot = cT.Output(
         name="scan_mode_dispersion_plot",

--- a/python/lsst/eo/pipe/spotMeasurementTask.py
+++ b/python/lsst/eo/pipe/spotMeasurementTask.py
@@ -1,6 +1,5 @@
 from lsst.afw import cameraGeom
 import lsst.afw.table as afw_table
-from lsst.cp.pipe._lookupStaticCalibration import lookupStaticCalibration
 import lsst.geom
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
@@ -25,8 +24,7 @@ class SpotMeasurementTaskConnections(pipeBase.PipelineTaskConnections,
         doc="Camera used in observations",
         storageClass="Camera",
         isCalibration=True,
-        dimensions=("instrument",),
-        lookupFunction=lookupStaticCalibration)
+        dimensions=("instrument",))
 
     spot_catalog = cT.Output(
         name="spot_catalog",


### PR DESCRIPTION
Changes to the QuantumGraph generation in [DM-38498](https://jira.lsstcorp.org/browse/DM-38498) affect how the LSSTCam camera object is obtained from the calibration collections.   Specifically, the `lookupStaticCalibration` function from `cp_pipe` is no longer available or needed.   These changes are associated with `lsst_distrib w_2023_35` and later.