### PR TITLE
handle ts8 pd data

### DIFF
--- a/python/lsst/eo/pipe/linearityPlotsTask.py
+++ b/python/lsst/eo/pipe/linearityPlotsTask.py
@@ -211,10 +211,10 @@ class LinearityPlotsTask(pipeBase.PipelineTask):
             photodiode.integrationMethod = self.pd_integration_method
             photodiode.currentScale = self.pd_current_scale
             pd_integral = photodiode.integrate()
-            if np.isnan(pd_integral):
-                self.log.warning("nan value found for pd_integral, "
-                                 "flipping the sign of pd_current_scale "
-                                 "and recomputing")
+            if camera.getName() == "LSST-TS8" and np.isnan(pd_integral):
+                self.log.warning("A nan value returned for the pd_integral "
+                                 "for LSST-TS8 data; flipping the sign of "
+                                 "pd_current_scale and recomputing.")
                 photodiode.currentScale = -self.pd_current_scale
                 pd_integral = photodiode.integrate()
             pd_integrals[exposure] \

--- a/python/lsst/eo/pipe/linearityPlotsTask.py
+++ b/python/lsst/eo/pipe/linearityPlotsTask.py
@@ -210,8 +210,15 @@ class LinearityPlotsTask(pipeBase.PipelineTask):
             photodiode = handle.get()
             photodiode.integrationMethod = self.pd_integration_method
             photodiode.currentScale = self.pd_current_scale
+            pd_integral = photodiode.integrate()
+            if np.isnan(pd_integral):
+                self.log.warning("nan value found for pd_integral, "
+                                 "flipping the sign of pd_current_scale "
+                                 "and recomputing")
+                photodiode.currentScale = -self.pd_current_scale
+                pd_integral = photodiode.integrate()
             pd_integrals[exposure] \
-                = photodiode.integrate()*pd_corr(physical_filter)
+                = pd_integral*pd_corr(physical_filter)
 
         # Fit linear model to each amp.
         detector = ptc_ref.dataId['detector']


### PR DESCRIPTION
The polarity of the pd current is flipped relative to LSSTCam data currently, resulting in nan values for the photodiode integral.  Flip the sign of the current scaling in those cases and recompute.