### PR TITLE
use combined frames for defects

### DIFF
--- a/bps/cp_pipe/bps_cpBias.yaml
+++ b/bps/cp_pipe/bps_cpBias.yaml
@@ -5,7 +5,7 @@ includeConfigs:
 isrTaskName: cpBiasIsr
 extraQgraphOptions: "{isr_QgraphOptions} --config {isrTaskName}:doDefect=False"
 
-pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpBias.yaml"
+pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpBias.yaml#cpBiasIsr,cpBiasCombine"
 instrument: ${INSTRUMENT_CLASS}
 
 payload:

--- a/bps/cp_pipe/bps_cpDark.yaml
+++ b/bps/cp_pipe/bps_cpDark.yaml
@@ -2,10 +2,10 @@ includeConfigs:
   - ${PWD}/bps/bps_butler_config.yaml
   - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
 
-isrTaskName: cpDarkIsr
-extraQgraphOptions: "{isr_QgraphOptions} --config {isrTaskName}:doDefect=False --config cpDark:repair.doCosmicRay=False"
+isrTaskName: cpDarkForDefectsIsr
+extraQgraphOptions: "{isr_QgraphOptions}"
 
-pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpDark.yaml"
+pipelineYaml: "${EO_PIPE_DIR}/pipelines/cpDarkForDefects.yaml"
 instrument: ${INSTRUMENT_CLASS}
 
 payload:

--- a/bps/cp_pipe/bps_cpDefects.yaml
+++ b/bps/cp_pipe/bps_cpDefects.yaml
@@ -1,0 +1,15 @@
+includeConfigs:
+  - ${PWD}/bps/bps_butler_config.yaml
+  - ${PWD}/bps/cp_pipe/bps_qgraph_options.yaml
+
+pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpDefects.yaml"
+instrument: ${INSTRUMENT_CLASS}
+
+payload:
+  b_protocol_run: ${B_PROTOCOL_RUN}
+  weekly: ${WEEKLY}
+  payload_modifier: ${PAYLOAD_MODIFIER}
+  inCollection: u/{operator}/flat{payload_modifier}_{b_protocol_run}_{weekly}
+  payloadName: defects{payload_modifier}_{b_protocol_run}_{weekly}
+  butlerConfig: ${BUTLER_CONFIG}
+  dataQuery: "instrument='${INSTRUMENT_NAME}'"

--- a/bps/cp_pipe/bps_cpFlat.yaml
+++ b/bps/cp_pipe/bps_cpFlat.yaml
@@ -5,7 +5,7 @@ includeConfigs:
 isrTaskName: cpFlatIsr
 extraQgraphOptions: "{isr_QgraphOptions} --config {isrTaskName}:doDefect=False --config {isrTaskName}:doLinearize=False --config cpFlatCombine:exposureScaling='Unity'"
 
-pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpFlat.yaml"
+pipelineYaml: "${CP_PIPE_DIR}/pipelines/${INSTRUMENT_NAME}/cpFlat.yaml#cpFlatIsr,cpFlatMeasure,cpFlatNormalize,cpFlatCombine"
 instrument: ${INSTRUMENT_CLASS}
 
 payload:

--- a/data/cp_pipelines_config.yaml
+++ b/data/cp_pipelines_config.yaml
@@ -13,7 +13,7 @@ b_protocol:
     - bps_cpBias.yaml
     - bps_cpDark.yaml
     - bps_cpFlat.yaml
-    - bps_cpDefectsIndividual.yaml
+    - bps_cpDefects.yaml
     - bps_cpPtc.yaml
   env_vars:
     - B_PROTOCOL_RUN

--- a/data/eo_pipelines_config.yaml
+++ b/data/eo_pipelines_config.yaml
@@ -26,7 +26,7 @@ b_protocol:
     - bps_eoBFAnalysis.yaml
     - bps_eoCtiVsFlux.yaml
     - bps_eoPersistence.yaml
-    - bps_eoScanMode.yaml
+#    - bps_eoScanMode.yaml
     - bps_eoBiasShifts.yaml
   env_vars:
     - B_PROTOCOL_RUN

--- a/pipelines/cpDarkForDefects.yaml
+++ b/pipelines/cpDarkForDefects.yaml
@@ -1,0 +1,13 @@
+# Note that if you edit this file you may also need to edit
+# cpDark.yaml.
+description:  dark calibration construction for defects.
+instrument: lsst.obs.lsst.LsstCam
+imports:
+  - location: $CP_PIPE_DIR/pipelines/_ingredients/cpDarkForDefects.yaml
+tasks:
+  cpDarkForDefectsIsr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      overscan.fitType: 'MEDIAN_PER_ROW'
+      doLinearize: false
+      doCrosstalk: false


### PR DESCRIPTION
Switch to using combined frames for defect data products used in ISR.  Also,
* Use `cp_pipe/pipelines/cpDarkForDefects.yaml` for combined darks used in `cpDefects.yaml` instead of disabling CR repair directly in eo_pipe bps config.
* Add `pipelines/cpDarkForDefects.yaml` since `cp_pipe w_2024_35` doesn't have this pipeline for `LSSTCam`
* Omit unneeded mosaic-related tasks in `cpBias` and `cpFlat` pipelines