### PR TITLE
handle bad ptc data in linearity task

### DIFF
--- a/python/lsst/eo/pipe/linearityPlotsTask.py
+++ b/python/lsst/eo/pipe/linearityPlotsTask.py
@@ -62,9 +62,11 @@ def linearity_fit(flux, Ne, y_range=(1e3, 9e4), max_frac_dev=0.05, logger=None):
     and omit any flux values above the Ne peak and any non-positive
     flux values.
     """
-    max_index = np.where(Ne == max(Ne))[0][0]
+    Ne_max = max(Ne)
+    max_index = np.where(Ne == Ne_max)[0][0]
     index = np.where((y_range[0] < Ne) & (Ne < y_range[1])
-                     & (flux <= flux[max_index]) & (flux > 0))
+                     & (flux <= flux[max_index]) & (flux > 0)
+                     & ~((flux > 0.9*flux[max_index]) & (Ne < 0.1*Ne_max)))
     aa = sum(flux[index])/sum(flux[index]**2/Ne[index])
 
     def func(x):

--- a/python/lsst/eo/pipe/linearityPlotsTask.py
+++ b/python/lsst/eo/pipe/linearityPlotsTask.py
@@ -264,7 +264,7 @@ class LinearityPlotsTask(pipeBase.PipelineTask):
                 notes[amp_name] \
                     = (f"{amp_name}\n"
                        f"max_frac_dev = {max_frac_dev:.1e}\n"
-                       f"max_observed_signal = {max_observed_signal:7.0f}\n"
+                       f"max_observed_signal = {max_observed_signal:7.0f} ADU\n"
                        f"linearity_turnoff = {linearity_turnoff:7.0f}")
                 plt.annotate(notes[amp_name], (0.05, 0.95),
                              xycoords='axes fraction', verticalalignment='top',


### PR DESCRIPTION
For run E749, the linearity results R42_S00 look like [this](https://s3df.slac.stanford.edu/data/rubin/lsstcam/E749/w_2024_35/R42/linearity_fit_plot_LSSTCam_R42_S00_u_lsstccs_eo_linearity_plots_E749_w_2024_35_20240926T111555Z.png).  With these changes the new result is 
![linearity_fit_plot_LSSTCam_R42_S00_u_jchiang_eo_linearity_plots_R42_E749_w_2024_35_20240926T194310Z](https://github.com/user-attachments/assets/c375afd6-c39b-4a3d-ac54-8684b2d08697)
