### PR TITLE
explicitly set retryUnlessExit to [2] in bps yaml configs

### DIFF
--- a/bps/bps_butler_config.yaml
+++ b/bps/bps_butler_config.yaml
@@ -1,3 +1,5 @@
 #includeConfigs:
 #  - resource://lsst.ctrl.bps/etc/bps_eb.yaml
 #  - ${PWD}/bps/bps_htcondor_configs.yaml
+
+retryUnlessExit: [2]


### PR DESCRIPTION
This will enable jobs that fail with `exit code 1` to be retried when using `ctrl_bps_htcondor`