### PR TITLE
Use clipped mean to evaluate signal and trailed regions in EPER method

### DIFF
--- a/python/lsst/eo/pipe/ctiVsFluxTask.py
+++ b/python/lsst/eo/pipe/ctiVsFluxTask.py
@@ -42,7 +42,7 @@ def find_flat_pairs(raws, flux_keyword=""):
     for unique_key in set(key_values):
         i0 = key_values.index(unique_key)
         try:
-            i1 = key_values.index(unique_key, i0)
+            i1 = key_values.index(unique_key, i0 + 1)
         except ValueError:
             # A complete key pair doesn't exist, so omit the raw exposure
             # associated with this key_value.
@@ -181,6 +181,8 @@ class CtiVsFluxTask(pipeBase.PipelineTask):
                 data['scti'].append(scti)
                 data['pcti'].append(pcti)
                 data[self.flux_keyword].append(target_flux)
+                data['expId_0'].append(flat0.dataId['exposure'])
+                data['expId_1'].append(flat1.dataId['exposure'])
         df0 = pd.DataFrame(data)
         df0.sort_values('signal', inplace=True)
 


### PR DESCRIPTION
Also,
* Add exposure ids to the `cti_vs_flux` data frame.
* Bug-fix to use both frames in a PTC flat pair.