### PR TITLE
updates to pd ingest script

### DIFF
--- a/bin.src/ingest_pd_data.py
+++ b/bin.src/ingest_pd_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 import os
 import argparse
+import time
 from lsst.eo.pipe import ingest_pd_data
 
 parser = argparse.ArgumentParser()
@@ -13,9 +14,16 @@ parser.add_argument("--repo", type=str, default="embargo_new",
                     help="Data repository")
 parser.add_argument("--dry_run", action='store_true', default=False,
                     help="Print the ingest commands, but do not execute.")
+parser.add_argument("--wait_time", type=float, default=5,
+                    help="Minutes to wait between butler queries for pd data")
 
 args = parser.parse_args()
 
-ingest_pd_data(args.run, instrument=args.instrument,
-               output_run=args.output_run, repo=args.repo,
-               dry_run=args.dry_run)
+while True:
+    num_ingested = ingest_pd_data(args.run, instrument=args.instrument,
+                                  output_run=args.output_run, repo=args.repo,
+                                  dry_run=args.dry_run)
+    if num_ingested == 0:
+        break
+    time.sleep(60*args.wait_time)
+

--- a/bin.src/inspect_raws.py
+++ b/bin.src/inspect_raws.py
@@ -90,9 +90,13 @@ if high_flux_filter is not None and low_flux_filter is not None:
     print(f"export LOW_FLUX_FILTER={low_flux_filter}")
 
 print()
-print(len(set(butler.registry.queryDatasets("photodiode", where=where,
-                                            collections=[f'{instrument}/photodiode']))),
-      "photodiode datasets")
+try:
+    print(len(set(butler.registry.queryDatasets("photodiode", where=where,
+                                                collections=[f'{instrument}/photodiode']))),
+          "photodiode datasets")
+except daf_butler.MissingCollectionError:
+    print(f"No collection {instrument}/photodiode found.")
+
 print(len(flats), "flat frames")
 print(len(ptc_flats), "flat/flat frames")
 print(len(unique_frames), "total frames")

--- a/python/lsst/eo/pipe/ingest_utils.py
+++ b/python/lsst/eo/pipe/ingest_utils.py
@@ -104,4 +104,5 @@ def ingest_pd_data(acq_run, instrument='LSSTCam', output_run=None,
                 print(eobj, flush=True)
             else:
                 ingested.append(pd_uri)
-    print(f"Ingested {len(ingested)} datasets.")
+    print(f"Ingested {len(ingested)} datasets.", flush=True)
+    return len(ingested)


### PR DESCRIPTION
Loop over the ingest function until no more uningested pd datasets are found for the specified run.   The default wait time between iterations is 5 mins and settable using the `--wait_time` option of `ingest_pd_data.py`